### PR TITLE
Use passive event listeners for touch events

### DIFF
--- a/src/touch-sideswipe.js
+++ b/src/touch-sideswipe.js
@@ -272,9 +272,9 @@
             if (winInnerWidth < opt.windowMaxWidth && !init) {
                 tssInitStates();
                 window.addEventListener('resize', tssRecalcStates, false);
-                elMain.addEventListener('touchstart', tssTouchstart, false);
-                elMain.addEventListener('touchmove', tssTouchmove, false);
-                elMain.addEventListener('touchend', tssTouchend, false);
+                elMain.addEventListener('touchstart', tssTouchstart, {passive: true});
+                elMain.addEventListener('touchmove', tssTouchmove, {passive: true});
+                elMain.addEventListener('touchend', tssTouchend, {passive: true});
                 elMain.addEventListener('click', elBgClick, false);
                 elLabel.addEventListener('click', elLabelClick, false);
             }


### PR DESCRIPTION
When using touch-sideswipe on a website, PageSpeed Insights recommends using passive event listeners for better mobile performance. More info here: https://web.dev/uses-passive-event-listeners/

This implementation requires passive event listeners to be supported by the browser. I find [compatibility](https://caniuse.com/passive-event-listener) is good enough for including the native implementation in the upstream code.